### PR TITLE
First cut at build infrastructure + an example source

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 
 ### Build Instructions
-#### Local Builds
+#### Local Build
 To build this repo locally, just execute the build script, e.g.:
 ```
 ./build.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-##
-Canifest -- \<TBD\>
+## Canifest
 
 ### What it is
 \<TBD\>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# canifest
-Container manifest tooling
+##
+Canifest -- \<TBD\>
+
+### What it is
+\<TBD\>
+
+
+### How to use it
+\<TBD\>
+
+
+### Build Instructions
+#### Local Builds
+To build this repo locally, just execute the build script, e.g.:
+```
+./build.sh
+```
+
+#### Multi OS build
+**PREP - only done once per build host**
+
+1. Make sure go is installed and owned by your user, e.g.: as root run:
+  - mkdir /opt/local
+  - tar -xvzf \<path_to_go_tarball\> -C /opt/local/
+  - chown -R \<user\> /opt/local/go
+
+2. Ensure GOROOT is set correctly, e.g.:
+  - export GOROOT=/opt/local/go
+  - export GOROOT_BOOTSTRAP=<path_to_systemwide_go>
+    - note: GOROOT_BOOTSTRAP must be different than GOROOT 
+
+3. Execute the prep build
+  - ./prep-build.sh 
+
+**Builds**
+
+1. Ensure GOROOT is set correctly, e.g.:
+  - export GOROOT=/opt/local/go
+2. Execute ./build-all.sh

--- a/build-all.sh
+++ b/build-all.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#
+# Script used to control the build
+# 
+# This script builds for 3 different Operating Systems:
+# - Linux (i386)
+# - OS X (i386)
+# - Windows (i386)
+#
+# SPECIAL CONSIDERATIONS
+# - Ensure the build environment is correctly configured for successful builds
+#   - i.e.: use the "pre-build.sh" script to setup the build machine
+#
+
+BIN=df_gen
+DESTDIR=bin
+
+which go &>/dev/null
+if [ $? -ne 0 -o -z "$GOROOT" ]
+then
+  echo "Failed to find GOROOT or the go executable - make sure it is set"
+  exit 1
+fi 
+
+export GOARCH=386
+export GOPATH=`pwd`
+
+for d in win linux osx;
+do
+  mkdir -p $DESTDIR/$d
+done
+
+# Ensure formatting is followed 
+go fmt df_generator
+
+echo "Building for Linux(386)"
+export GOOS=linux
+go build -o $DESTDIR/linux/${BIN} df_generator
+
+echo "Building for OS X/Darwin(386)"
+export GOOS=darwin
+go build -o $DESTDIR/osx/${BIN} df_generator
+
+echo "Building for Windows(386)"
+export GOOS=windows
+go build -o $DESTDIR/win/${BIN}.exe df_generator
+

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#
+# Script used to control the build
+# 
+
+BIN=df_gen
+DESTDIR=bin
+
+which go &>/dev/null
+if [ $? -ne 0 -o -z "$GOROOT" ]
+then
+  echo "Failed to find GOROOT or the go executable - make sure it is set"
+  exit 1
+fi 
+
+export GOARCH=386
+export GOPATH=`pwd`
+
+mkdir -p $DESTDIR
+
+# Ensure formatting is followed 
+go fmt df_generator
+
+echo "Building..."
+go build -o $DESTDIR/linux/${BIN} df_generator
+

--- a/prep-build.sh
+++ b/prep-build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+which go &>/dev/null
+if [ $? -ne 0 -o -z "$GOROOT" ]
+then
+  echo "Failed to find GOROOT or the go executable - make sure it is set"
+  exit 1
+fi 
+
+# Is this a valid workaround ??
+# export GOROOT_BOOTSTRAP=$GOROOT
+
+export GOARCH=386
+
+echo "Preparing builds for Linux(386)"
+export GOOS=linux
+# cd $GOROOT/src; ./make.bash --no-clean
+cd $GOROOT/src; ./make.bash
+
+echo "Preparing builds for OS X/Darwin(386)"
+export GOOS=darwin
+cd $GOROOT/src; ./make.bash --no-clean
+
+echo "Preparing builds for Windows(386)"
+export GOOS=windows
+cd $GOROOT/src; ./make.bash --no-clean
+
+# cd $GOROOT/src; ./all.bash

--- a/src/df_generator/assets/README.md
+++ b/src/df_generator/assets/README.md
@@ -1,0 +1,1 @@
+###### Placeholder

--- a/src/df_generator/main.go
+++ b/src/df_generator/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"text/template"
+)
+
+type DockerFile struct {
+	From       string
+	Maintainer string
+	Label      string
+}
+
+func main() {
+	df := DockerFile{"Fedora", "Who Knows <whothere@redhat.com>", "Description=\"This image is just an example...\""}
+
+	content, _ := ioutil.ReadFile("templates/DockerFile.tmpl")
+	tmpl, err := template.New("DockerFile").Parse(string(content))
+	if err != nil {
+		log.Panic(err)
+	}
+
+	tmpl.Execute(os.Stdout, df)
+}

--- a/templates/DockerFile.tmpl
+++ b/templates/DockerFile.tmpl
@@ -1,0 +1,8 @@
+From: {{.From}}
+
+Maintainer: {{.Maintainer}}
+
+Label: {{.Label}}
+
+
+

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,2 @@
+###### GO Lang Templates
+Templates are used to control the output of data produced by the go program. In this case, the DockerFile.tmpl is used to generate the DockerFile according to specifications while the go program fills in the dynamic content. 


### PR DESCRIPTION
Introducing the build scripts to be used by the Jenkins job (+ local builds)

Also, added an example source to show some capabilities around templates in go (+ needed a source tree to use for setting up the build jobs)